### PR TITLE
check for intent to shift before setting center

### DIFF
--- a/src/ol3-popup.js
+++ b/src/ol3-popup.js
@@ -95,25 +95,31 @@ ol.Overlay.Popup.prototype.panIntoView_ = function(coord) {
 
     var center = this.getMap().getView().getCenter(),
         px = this.getMap().getPixelFromCoordinate(center);
-
+    
+    var doShift = false;
     if (fromRight < 0) {
         px[0] -= fromRight;
+        doShift = true;
     } else if (fromLeft < 0) {
         px[0] += fromLeft;
+        doShift = true;
     }
 
     if (fromTop < 0) {
         px[1] += fromTop;
+        doShift = true;
     } else if (fromBottom < 0) {
         px[1] -= fromBottom;
+        doShift = true;
     }
 
     if (this.ani && this.ani_opts) {
         this.ani_opts.source = center;
         this.getMap().beforeRender(this.ani(this.ani_opts));
     }
-    this.getMap().getView().setCenter(this.getMap().getCoordinateFromPixel(px));
-
+    if (doShift) {
+        this.getMap().getView().setCenter(this.getMap().getCoordinateFromPixel(px));
+    }
     return this.getMap().getView().getCenter();
 
 };


### PR DESCRIPTION
Because of float precision, this.getMap().getCoordinateFromPixel(this.getMap().getPixelFromCoordinate(center)) 
is not always equal to center. Calling setCenter anyway causes an imperceptible fractional shift in the 
view extent that can accidentally trigger undesired feature load events.