### PR TITLE
#17 support popup tooltip mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ The examples demonstrate usage and can be viewed online thanks to [RawGit](http:
     * Controlling popup dimensions and scrolling overflowing content
 * [Multiple popups](http://rawgit.com/walkermatt/ol3-popup/master/examples/multiple.html)
     * Add a new popup each time the maps is clicked
-
+* [Tooltip](http://rawgit.com/walkermatt/ol3-popup/master/examples/tooltip.html)
+    * Create a popup instance as tooltip (on map 'pointermove')
+    
 The source for all examples can be found in [examples](examples).
 
 ## API
@@ -29,7 +31,7 @@ See [the examples](./examples) for usage. Styling can be done via CSS.
 
 |Name|Type|Description|
 |:---|:---|:----------|
-|`opt_options`|`Object`| Overlay options, extends olx.OverlayOptions adding: **`panMapIfOutOfView`** `Boolean` - Should the map be panned so that the popup is entirely within view. |
+|`opt_options`|`Object`| Overlay options, extends olx.OverlayOptions adding: **`panMapIfOutOfView`** `Boolean` - Should the map be panned so that the popup is entirely within view. **`isTooltip`** `Boolean` - Should the popup tooltip mode used instead of classic popup |
 
 #### Extends
 
@@ -56,6 +58,10 @@ Hide the popup.
 ##### `isOpened()`
 
 Indicates if the popup is in open state
+
+##### `isTooltip()`
+
+Indicates if the popup is a tooltip
 
 ## Contributing
 

--- a/examples/tooltip.html
+++ b/examples/tooltip.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>OpenLayers 3 - Popup - tooltip</title>
+    <meta name="viewport" content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/ol3/3.14.0/ol.css" />
+    <link rel="stylesheet" href="../src/ol3-popup.css" />
+    <link rel="stylesheet" href="popup.css" />
+  </head>
+  <body>
+    <div id="map"></div>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/ol3/3.14.0/ol.js"></script>
+    <script src="../src/ol3-popup.js"></script>
+    <script src="tooltip.js"></script>
+  </body>
+</html>

--- a/examples/tooltip.js
+++ b/examples/tooltip.js
@@ -1,0 +1,52 @@
+var map = new ol.Map({
+    target: 'map',
+    layers: [
+        new ol.layer.Tile({
+            source: new ol.source.OSM()
+        }),
+        new ol.layer.Image({
+            source: new ol.source.ImageVector({
+                source: new ol.source.Vector({
+                    url: 'https://openlayers.org/en/v3.14.0/examples/data/geojson/countries.geojson',
+                    format: new ol.format.GeoJSON()
+                }),
+                style: new ol.style.Style({
+                fill: new ol.style.Fill({
+                    color: 'rgba(255, 255, 255, 0.6)'
+                }),
+                stroke: new ol.style.Stroke({
+                    color: '#319FD3',
+                    width: 1
+                })
+            })
+        })
+    })
+    ],
+    view: new ol.View({
+        center: [0, 0],
+        zoom: 2
+    })
+});
+
+var tooltip = new ol.Overlay.Popup({isTooltip: true});
+map.addOverlay(tooltip);
+
+var displayTooltip = function(evt) {
+    var feature = map.forEachFeatureAtPixel(evt.pixel, function(feature) {
+        return feature;
+    });
+
+    if (feature) {
+        var tooltipContent = feature.get('name');
+        tooltip.show(evt.coordinate, tooltipContent);
+	} else {
+		tooltip.hide();
+	}	  
+};
+
+map.on('pointermove', function(evt) {
+    if (evt.dragging) {
+      return;
+    }
+    displayTooltip(evt);
+});

--- a/src/ol3-popup.css
+++ b/src/ol3-popup.css
@@ -68,3 +68,53 @@
 .ol-popup.marker {
     margin-bottom: 30px;
 }
+
+/**
+ * Tooltip popup
+ *
+ */
+.ol-tooltip {
+    background-color: transparent;
+    bottom: 12px;
+    display: none;
+    left: -50px; padding: 0;
+    position: absolute;
+}
+
+.ol-tooltip:after, .ol-tooltip:before {
+    border: solid transparent;
+    content: " ";
+    height: 0;
+    pointer-events: none;
+    position: absolute;
+    top: 100%;
+    width: 0;
+}
+
+.ol-tooltip:after {
+    border-top-color: rgba(237,239,151,.8);
+    border-width: 10px;
+    left: 48px;
+    margin-left: -10px;
+}
+
+.ol-tooltip:before {
+    border-top-color: transparent;
+    border-width: 11px;
+    left: 48px;
+    margin-left: -11px;
+}
+.ol-tooltip-content {
+    background-color: rgba(237,239,151,.8);
+    border-radius: 8px;
+    box-shadow: 2px 2px 2px rgba(0,0,0,.4);
+    color: rgba(0,0,0,.8);
+    font-family: Verdana, Geneva, Helvetica, Arial, sans-serif;
+    font-size: 10px;
+    max-height: 200px;
+    min-width: 100px;
+    width:auto;
+    overflow-x: auto;
+    padding: 4px 8px;
+}
+

--- a/src/ol3-popup.js
+++ b/src/ol3-popup.js
@@ -7,6 +7,8 @@
  *                              **`panMapIfOutOfView`** `Boolean` - Should the
  *                              map be panned so that the popup is entirely
  *                              within view.
+ *                              **`isTooltip`** `Boolean` - Should the popup tooltip
+ *                              mode used instead of classic popup			
  */
 ol.Overlay.Popup = function(opt_options) {
 
@@ -17,6 +19,8 @@ ol.Overlay.Popup = function(opt_options) {
         this.panMapIfOutOfView = true;
     }
 
+    this.isTooltip = (options.isTooltip)? options.isTooltip : false;
+	
     this.ani = options.ani;
     if (this.ani === undefined) {
         this.ani = ol.animation.pan;
@@ -28,22 +32,24 @@ ol.Overlay.Popup = function(opt_options) {
     }
 
     this.container = document.createElement('div');
-    this.container.className = 'ol-popup';
+    this.container.className = (this.isTooltip) ? 'ol-tooltip' : 'ol-popup';
 
-    this.closer = document.createElement('a');
-    this.closer.className = 'ol-popup-closer';
-    this.closer.href = '#';
-    this.container.appendChild(this.closer);
+    if( !this.isTooltip ) {
+        this.closer = document.createElement('a');
+        this.closer.className = 'ol-popup-closer';
+        this.closer.href = '#';
+        this.container.appendChild(this.closer);
 
-    var that = this;
-    this.closer.addEventListener('click', function(evt) {
-        that.container.style.display = 'none';
-        that.closer.blur();
-        evt.preventDefault();
-    }, false);
+        var that = this;
+        this.closer.addEventListener('click', function(evt) {
+            that.container.style.display = 'none';
+            that.closer.blur();
+            evt.preventDefault();
+        }, false);
+    }
 
     this.content = document.createElement('div');
-    this.content.className = 'ol-popup-content';
+    this.content.className = ( this.isTooltip )? 'ol-tooltip-content' : 'ol-popup-content';
     this.container.appendChild(this.content);
 
     // Apply workaround to enable scrolling of content div on touch devices
@@ -177,4 +183,12 @@ ol.Overlay.Popup.prototype.hide = function() {
  */
 ol.Overlay.Popup.prototype.isOpened = function() {
     return this.container.style.display == 'block';
+};
+
+
+/**
+ * Indicates if the popup is a tooltip
+ */
+ol.Overlay.Popup.prototype.isTooltip = function() {
+    return this.isTooltip;
 };

--- a/util/README.md
+++ b/util/README.md
@@ -15,7 +15,9 @@ The examples demonstrate usage and can be viewed online thanks to [RawGit](http:
     * Controlling popup dimensions and scrolling overflowing content
 * [Multiple popups](http://rawgit.com/walkermatt/ol3-popup/master/examples/multiple.html)
     * Add a new popup each time the maps is clicked
-
+* [Tooltip](http://rawgit.com/walkermatt/ol3-popup/master/examples/tooltip.html)
+    * Create a popup instance as tooltip (on map 'pointermove')
+    
 The source for all examples can be found in [examples](examples).
 
 ## API


### PR DESCRIPTION
As discussed in #17:
* util README master file was modified to add the example. 
* Root README file regenerated using ``npm run doc``, but only keeping the changes (last PR i've seen the entire file was overwriten)
* For the example, i've already added the rawgit link corresponding to your master rep. For sure it's not active yet, but you can see it the PR working example at http://rawgit.com/eblondel/ol3-popup/ol-tooltip/examples/tooltip.html It is based on some sample data given through OL3 , and an image vector layer (inspired by http://openlayers.org/en/v3.14.0/examples/image-vector-layer.html)

Best,
Emmanuel